### PR TITLE
noExternalResolve option for control over files automatically pulled into compilation, declarationFiles and declarationOuput option for batching d.ts files output

### DIFF
--- a/lib/CompileError.js
+++ b/lib/CompileError.js
@@ -1,16 +1,22 @@
 function CompileError(info) {
     SyntaxError.call(this);
 
-    var startPos = info.file.getLineAndCharacterFromPosition(info.start);
+	if (info.file) {
+		var startPos = info.file.getLineAndCharacterFromPosition(info.start);
 
-    this.fileName = info.file.filename;
-    this.line = startPos.line;
-    this.column = startPos.character;
-    this.name = 'TS' + info.code;
-    this.message = info.file.filename +
-    	'(' + startPos.line + ',' + startPos.character + '): ' +
-    	'TS' + info.code + ': ' +
-    	info.messageText;
+		this.fileName = info.file.filename;
+		this.line = startPos.line;
+		this.column = startPos.character;
+		this.name = 'TS' + info.code;
+		this.message = info.file.filename +
+		'(' + startPos.line + ',' + startPos.character + '): ' +
+		'TS' + info.code + ': ' +
+		info.messageText;
+	} else {
+		this.name = 'TS' + info.code;
+		this.message = 'TS' + info.code + ': ' + info.messageText;
+	}
+
 }
 
 CompileError.prototype = Object.create(SyntaxError.prototype);

--- a/lib/Host.js
+++ b/lib/Host.js
@@ -10,7 +10,7 @@ var libDefault = ts.createSourceFile(
 	ts.ScriptTarget.ES3,
 	'0');
 
-function Host(currentDirectory, languageVersion) {
+function Host(currentDirectory, languageVersion, externalResolve) {
 	this.currentDirectory = currentDirectory;
 	this.languageVersion = languageVersion;
 	this.files = {};
@@ -18,6 +18,7 @@ function Host(currentDirectory, languageVersion) {
 	this.output = {};
 	this.version = 0;
 	this.error = false;
+	this.externalResolve = externalResolve;
 }
 
 Host.prototype._reset = function () {
@@ -85,20 +86,51 @@ Host.prototype.writeFile = function (filename, data) {
 };
 
 Host.prototype.getSourceFile = function (filename) {
-	var normalized = ts.normalizePath(filename);
-
-	if (this.files[normalized])
-		return this.files[normalized].ts;
-
-	if (normalized === '__lib.d.ts')
+	var text;
+	var normalizedFilename = ts.normalizePath(filename);
+	if (this.files[normalizedFilename]) {
+		if (this.files[normalizedFilename] === Host.unresolvedFile) {
+			return undefined;
+		}
+		else {
+			return this.files[normalizedFilename].ts;
+		}
+	}
+	else if (normalizedFilename === '__lib.d.ts') {
 		return libDefault;
-
-	return this._addFile(filename, false);
+	}
+	else {
+		if (this.externalResolve) {
+			try {
+				text = fs.readFileSync(filename).toString('utf8');
+			}
+			catch (ex) {
+				return undefined;
+			}
+		}
+	}
+	if (typeof text !== 'string')
+		return undefined;
+	var file = ts.createSourceFile(filename, text, this.languageVersion, String(this.version));
+	this.files[normalizedFilename] = {
+		filename: normalizedFilename,
+		originalFilename: filename,
+		content: text,
+		ts: file
+	};
+	return file;
 };
 
 Host.prototype.getFileData = function(filename) {
 	var normalized = ts.normalizePath(filename);
 	return this.files[normalized];
+};
+
+Host.unresolvedFile = {
+	filename: undefined,
+	originalFilename: undefined,
+	content: undefined,
+	ts: undefined
 };
 
 module.exports = Host;

--- a/lib/Tsifier.js
+++ b/lib/Tsifier.js
@@ -2,17 +2,19 @@ var convert = require('convert-source-map');
 var events  = require('events');
 var log     = require('debuglog')(require('../package').name);
 var path    = require('path');
+var glob = require('glob');
 var through = require('through2');
 var time    = require('./time');
 var util    = require('util');
 var _       = require('lodash');
+var fs = require('fs');
 
 var CompileError = require('./CompileError');
 var Host         = require('./Host');
 var ts           = require('./tsc/tsc');
 
 function isTypescript(file) {
-	return (/\.ts$/i).test(file);
+	return !isTypescriptDeclaration(file) && (/\.ts$/i).test(file);
 }
 
 function isTypescriptDeclaration(file) {
@@ -23,38 +25,60 @@ function tsToJs(tsFile) {
 	return tsFile.replace(/\.ts$/i, '.js');
 }
 
-function getRelativeFilename(file) {
-	return './' + path.relative(process.cwd(), file)
-		.replace(/\\/g, '/');
+function tsToDts(tsFile) {
+	return tsFile.replace(/\.ts$/i, '.d.ts');
+}
+
+function getAbsoluteFilename(file) {
+	return path.resolve(file);
+}
+
+function unixStylePath(filePath) {
+	return filePath.split(path.sep).join('/');
 }
 
 function Tsifier(opts) {
 	opts = opts || {};
+    this.sourceRoot = opts.sourceRoot || './',
 	this.opts = {
 		module: 'commonjs',
 		noImplicitAny: opts.noImplicitAny || false,
 		removeComments: opts.removeComments || false,
+		declaration: Boolean(opts.declarationOutput),
+		declarationFiles: opts.declarationFiles || '',
+		declarationOutput: opts.declarationOutput || '',
 		sourceMap: true,
+		noExternalResolve: opts.noExternalResolve || false,
 		target: ts.ScriptTarget[opts.target || opts.t || 'ES3'],
 		skipWrite: true
 	};
-	this.host = new Host(process.cwd(), this.opts.target);
+	this.host = new Host(process.cwd(), this.opts.target, !this.opts.noExternalResolve);
 }
 
 util.inherits(Tsifier, events.EventEmitter);
 
 Tsifier.prototype.reset = function () {
 	this.host._reset();
+	this.declarationContent = '';
 };
 
 Tsifier.prototype.generateCache = function (files) {
 	var tsFiles = files.filter(isTypescript)
-		.map(getRelativeFilename);
+		.map(getAbsoluteFilename);
 	if (tsFiles.length === 0)
 		return;
 
-	this.addAll(tsFiles);
-	this.compile();
+	var self = this;
+	glob(self.opts.declarationFiles, {}, function (error, files) {
+		var dtsFiles = files.filter(isTypescriptDeclaration)
+			.map(getAbsoluteFilename);
+		dtsFiles.forEach(function (file) {
+			self.host._addFile(file, true);
+		});
+
+		self.addAll(tsFiles);
+		self.compile();
+	});
 };
 
 Tsifier.prototype.addAll = function (files) {
@@ -109,7 +133,7 @@ Tsifier.prototype.transform = function (file) {
 		next();
 	}
 	function flush(next) {
-		var compiled = self.getCompiledFile(getRelativeFilename(file));
+		var compiled = self.getCompiledFile(getAbsoluteFilename(file));
 		if (compiled) {
 			this.push(compiled);
 		}
@@ -139,16 +163,53 @@ Tsifier.prototype.getCompiledFile = function (tsFile) {
 	}
 
 	var sourcemap = convert.fromJSON(this.host.output[jsFile + '.map']);
-	sourcemap.setProperty('sources', [normalized]);
+	sourcemap.setProperty('sources', [path.relative(path.resolve(process.cwd(), this.sourceRoot), normalized)]);
 	sourcemap.setProperty('sourcesContent', [self.host.files[normalized].contents]);
 	return output.replace(convert.mapFileCommentRegex, sourcemap.toComment());
 };
 
+Tsifier.prototype.emitDeclaration = function (tsFile) {
+	var self = this;
+
+	if (self.host.error)
+		return;
+
+	var normalized = ts.normalizePath(tsFile);
+	var dtsFile = tsToDts(normalized);
+
+	var output = self.host.output[dtsFile];
+	if (!output) {
+		log('Cache miss on %s', normalized);
+		self.generateCache([dtsFile]);
+		if (self.host.error)
+			return;
+		output = self.host.output[dtsFile];
+		if (!output)
+			return;
+	}
+
+	self.declarationContent += 'declare module "' + unixStylePath(path.relative('../', dtsFile.slice(0,-5))) + '" {\n\t'
+	self.declarationContent += output.split('declare ').join('').split('\n').join('\n\t') + "\n"
+	self.declarationContent += '}';
+}
+
 Tsifier.prototype.emitFiles = function () {
 	var self = this;
+
 	_.keys(self.host.files).forEach(function (file) {
-		self.emit('file', path.resolve(file));
+		if (isTypescript(file)) {
+			if (self.opts.declarationOutput)
+				self.emitDeclaration(file);
+			self.emit('file', path.resolve(file));
+		}
 	});
+
+	if (self.opts.declarationOutput) {
+		fs.writeFile(self.opts.declarationOutput, self.declarationContent, function(err) {
+			if (err)
+				throw err;
+		});
+	}
 };
 
 module.exports = Tsifier;

--- a/lib/Tsifier.js
+++ b/lib/Tsifier.js
@@ -190,7 +190,7 @@ Tsifier.prototype.emitDeclaration = function (tsFile) {
 
 	self.declarationContent += 'declare module "' + unixStylePath(path.relative('../', dtsFile.slice(0,-5))) + '" {\n\t'
 	self.declarationContent += output.split('declare ').join('').split('\n').join('\n\t') + "\n"
-	self.declarationContent += '}';
+	self.declarationContent += '}\n\n';
 }
 
 Tsifier.prototype.emitFiles = function () {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "browserify": "^9.0.3",
     "event-stream": "^3.2.1",
     "fs-extra": "^0.16.3",
+    "glob": "^5.0.2",
     "jshint": "^2.5.11",
     "jshint-stylish": "^1.0.0",
     "node-foo": "^0.2.3",


### PR DESCRIPTION
 * noExternalResolve option (defaults to false) to allow a gulp-typescript way of defining all files to include (without trying to automatically pull dependencies in)
 * declarationFiles option is a glob that defines d.ts files to be used in teh compilation process
 * declarationOuput allows a batched d.ts file to be output from the compiler, using ambient module declarations

**Additional updates**
introduced a fix for require paths to be compatible across dependencies in the node_modules folder (using absolute paths in the compiler)
fixed reporting errors thrown by the compiler not related to file errors
fixed file emit event to only include .ts file (leave out d.ts files)