### PR TITLE
Passing an own instance of the TypeScript compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Specify ECMAScript target version: 'ES3' (default), 'ES5', or 'ES6'
 
 Stop processing output when there are typing errors.
 
+#### --typescript
+
+Possibility for passing an own instance of the TypeScript compiler (forked version etc.).
+
 # does this work with...
 
 ### Watchify?

--- a/lib/Tsifier.js
+++ b/lib/Tsifier.js
@@ -31,14 +31,27 @@ function getRelativeFilename(file) {
 function Tsifier(opts) {
 	opts = opts || {};
 
-	var target = ts.ScriptTarget[opts.target || opts.t || 'ES3'];
-	this.opts = {
-		noImplicitAny: opts.noImplicitAny || false,
-		removeComments: opts.removeComments || false,
-		sourceMap: true,
-		target: target
+	var defaults = {
+		module: 'commonjs',
+		noImplicitAny: false,
+		removeComments: false,
+		sourceMap: true
 	};
-	if (target !== ts.ScriptTarget.ES6) {
+
+	//
+	// Use the passed typescript compiler instance if available
+	//
+	if (opts.typescript) {
+		ts = opts.typescript;
+
+		delete opts.typescript;
+	}
+
+	this.opts = util._extend(defaults, opts);
+
+	this.opts.target = ts.ScriptTarget[opts.target.toUpperCase() || 'ES3'];
+
+	if (this.opts.target !== ts.ScriptTarget.ES6) {
 		this.opts.module = 'commonjs';
 	}
 


### PR DESCRIPTION
There are sometimes scenarios where you have to use an own instance of the TypeScript compiler (a fork like [jsx-typescript](https://github.com/fdecampredon/jsx-typescript), etc.). This PR contains the functionality for passing those own instances.

Furthermore it provides the functionality for passing the complete range of compiler flags straight to the TSC.

Hope you find it useful :)