### PR TITLE
Add support for typescript 1.5 --inlineSourceMap and --inlineSources

### DIFF
--- a/lib/Tsifier.js
+++ b/lib/Tsifier.js
@@ -47,7 +47,13 @@ module.exports = function (ts) {
 		}, null, '');
 
 		// Always generate sourcemaps; browserify will only use these if --debug is set
-		parsed.options.sourceMap = true;
+		// Adding support for inlineSourceMap
+		parsed.options.sourceMap = !parsed.options.inlineSourceMap;
+		
+		if (parsed.options.inlineSourceMap) {
+			//add inlineSource to generate sourceContent
+			parsed.options.inlineSources = true;
+		}
 
 		// Use CommonJS module mode unless we are in ES6 mode (where it is invalid)
 		parsed.options.module = parsed.options.target === ts.ScriptTarget.ES6 ?
@@ -60,6 +66,7 @@ module.exports = function (ts) {
 		delete parsed.options.outDir;
 
 		return parsed.options;
+
 	}
 
 	function Tsifier(opts) {
@@ -237,11 +244,16 @@ module.exports = function (ts) {
 				return;
 			return self.getCompiledFile(tsFile, true);
 		}
-
-		var sourcemap = convert.fromJSON(this.host.output[outputFile + '.map']);
-		sourcemap.setProperty('sources', [normalized]);
-		sourcemap.setProperty('sourcesContent', [self.host.files[normalized].contents]);
-		return output.replace(convert.mapFileCommentRegex, sourcemap.toComment());
+		
+		if (!self.opts.inlineSourceMap) {
+			var sourcemap = convert.fromJSON(this.host.output[outputFile + '.map']);
+			sourcemap.setProperty('sources', [normalized]);
+			sourcemap.setProperty('sourcesContent', [self.host.files[normalized].contents]);
+			
+			output = output.replace(convert.mapFileCommentRegex, sourcemap.toComment());
+		}
+		
+		return output
 	};
 
 	var result = Tsifier;

--- a/lib/Tsifier.js
+++ b/lib/Tsifier.js
@@ -49,11 +49,6 @@ module.exports = function (ts) {
 		// Always generate sourcemaps; browserify will only use these if --debug is set
 		// Adding support for inlineSourceMap
 		parsed.options.sourceMap = !parsed.options.inlineSourceMap;
-		
-		if (parsed.options.inlineSourceMap) {
-			//add inlineSource to generate sourceContent
-			parsed.options.inlineSources = true;
-		}
 
 		// Use CommonJS module mode unless we are in ES6 mode (where it is invalid)
 		parsed.options.module = parsed.options.target === ts.ScriptTarget.ES6 ?
@@ -245,15 +240,16 @@ module.exports = function (ts) {
 			return self.getCompiledFile(tsFile, true);
 		}
 		
-		if (!self.opts.inlineSourceMap) {
-			var sourcemap = convert.fromJSON(this.host.output[outputFile + '.map']);
-			sourcemap.setProperty('sources', [normalized]);
-			sourcemap.setProperty('sourcesContent', [self.host.files[normalized].contents]);
-			
-			output = output.replace(convert.mapFileCommentRegex, sourcemap.toComment());
-		}
+		var sourcemap = !self.opts.inlineSourceMap ?
+			convert.fromJSON(this.host.output[outputFile + '.map']) :
+			convert.fromComment(this.host.output[outputFile]) ;
 		
-		return output
+		if (!self.opts.inlineSources) {
+			sourcemap.setProperty('sources', [normalized]);
+		}
+		sourcemap.setProperty('sourcesContent', [self.host.files[normalized].contents]);
+		
+		return output.replace(convert.mapFileCommentRegex, sourcemap.toComment());
 	};
 
 	var result = Tsifier;

--- a/lib/Tsifier.js
+++ b/lib/Tsifier.js
@@ -247,9 +247,11 @@ module.exports = function (ts) {
 		if (!self.opts.inlineSources) {
 			sourcemap.setProperty('sources', [normalized]);
 		}
-		sourcemap.setProperty('sourcesContent', [self.host.files[normalized].contents]);
 		
-		return output.replace(convert.mapFileCommentRegex, sourcemap.toComment());
+		sourcemap.setProperty('sourcesContent', [self.host.files[normalized].contents]);
+		var sourceMapRegex = self.opts.inlineSourceMap ? convert.commentRegex : convert.mapFileCommentRegex;
+		
+		return output.replace(sourceMapRegex, sourcemap.toComment());
 	};
 
 	var result = Tsifier;

--- a/test/test.js
+++ b/test/test.js
@@ -234,6 +234,16 @@ test('with tsconfig.json', function (t) {
 	});
 });
 
+test('with tsconfig.json using inlineSourceMap', function (t) {
+	process.chdir('./test/tsInlinesourceMap');
+	run('./x.ts', { }, function (errors, actual) {
+		expectNoErrors(t, errors);
+		expectConsoleOutputFromScript(t, actual, [3]);
+		process.chdir('../..');
+		t.end();
+	});
+});
+
 test('with custom compiler', function (t) {
 	var ts = _.clone(require('typescript'));
 

--- a/test/tsInlinesourceMap/tsconfig.json
+++ b/test/tsInlinesourceMap/tsconfig.json
@@ -1,0 +1,5 @@
+{
+	"compilerOptions": {
+		"inlineSourceMap": true
+	}
+}

--- a/test/tsInlinesourceMap/x.ts
+++ b/test/tsInlinesourceMap/x.ts
@@ -1,0 +1,3 @@
+let x ;
+x = 3;
+console.log(x);


### PR DESCRIPTION
This PR add support for ts params inlineSources and inlineSourceMap and also fixes issue #74 .

When using the -debug option in browserify we now have two differents sourceMap outputs : 

1. --inlineSources is undefined or false => sourceMap output will preserve the folder hierarchy 
![image2](https://cloud.githubusercontent.com/assets/6756203/9832711/d25631e6-5983-11e5-8e62-7486dff76a0a.PNG)
2. --inlineSources is true => sourceMap output will not preserve the folder hierarchy 
![image1](https://cloud.githubusercontent.com/assets/6756203/9832712/e053f008-5983-11e5-9796-d8f693451a62.PNG)
